### PR TITLE
refactor reviews routes into separate file

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,7 @@ import Root from './components/Root';
 import configureStore from './store/store';
 import { fetchProfile } from './util/profile_api_util';
 import {login, logout} from './actions/session_actions';
+import { createReview } from './actions/review_actions';
 
 document.addEventListener('DOMContentLoaded',()=>{
   let store;
@@ -28,7 +29,9 @@ document.addEventListener('DOMContentLoaded',()=>{
     store = configureStore({});
   }
   window.getState = store.getState;
+  window.dispatch = store.dispatch;
   window.fetchProfile = fetchProfile;
+  window.createReview = createReview;
   window.login = login;
   window.logout = logout;
   ReactDOM.render(<Root store={store} />, document.getElementById('root'));

--- a/routes/api/reviews.js
+++ b/routes/api/reviews.js
@@ -1,0 +1,64 @@
+const express = require("express");
+const router = express.Router({mergeParams: true});
+const Review = require("../../models/Review");
+const passport = require("passport");
+
+//fetch reviews
+router.get(
+  "/", 
+  (req, res) => {
+    debugger;
+  Review.find({ spotId: req.params.spotId })
+    .sort({ createdAt: -1 })
+    .then(reviews => res.json(reviews))
+    .catch(err => res.status(400).json(err));
+});
+
+//create review
+router.post(
+  "/",
+  passport.authenticate("jwt", { session: false }),
+  (req, res) => {
+    const newReview = new Review({
+      creatorId: req.user.id,
+      spotId: req.params.spotId,
+      quality: req.body.quality,
+      difficulty: req.body.difficulty,
+      title: req.body.title,
+      body: req.body.body
+    });
+    newReview
+      .save()
+      .then(review => res.json(review))
+      .catch(err => res.status(400).json(err));
+  }
+);
+
+//delete review
+router.delete(
+  "/:id",
+  passport.authenticate("jwt", { session: false }),
+  (req, res) => {
+    Review.findById(req.params.id).then(review => {
+      if (!review) {
+        return res.status(404).json({ error: "Can't find that review" });
+      }
+      Review.deleteOne(review)
+        .then(() => res.status(200).json({ msg: "review deleted" }))
+        .catch(err => console.log(err));
+    });
+  }
+);
+
+//update review
+router.patch(
+  "/:id",
+  passport.authenticate("jwt", { session: false }),
+  (req, res) => {
+    Review.findByIdAndUpdate(req.params.id, req.body, { new: true })
+      .then(review => res.json(review))
+      .catch(err => console.log(err));
+  }
+);
+
+module.exports = router;

--- a/routes/api/spots.js
+++ b/routes/api/spots.js
@@ -7,6 +7,7 @@ const Favorite = require('../../models/Favorite');
 const jwt = require('jsonwebtoken');
 const keys = require("../../config/keys");
 const passport = require('passport');
+const reviews = require('./reviews');
 
 // create surf spot
 // require user to be logged in to create surf spot
@@ -81,60 +82,6 @@ router.patch('/:id',
           .catch(err => console.log(err));
   });
 
-// get all reviews for a surf spot
-router.get('/:id/reviews', (req, res) => {
-  Review
-    .find({ spotId: req.params.id })
-    .sort({ createdAt: -1 })
-    .then(reviews => res.json(reviews))
-    .catch(err => res.status(400).json(err));
-})
-
-// create a review for a surf spot
-router.post('/:id/reviews', 
-  passport.authenticate("jwt", { session: false }),
-  (req, res) => {
-    const newReview = new Review ({
-      creatorId: req.user.id,
-      spotId: req.params.id,
-      quality: req.body.quality,
-      difficulty: req.body.difficulty,
-      title: req.body.title,
-      body: req.body.body
-    });
-    newReview.save()
-      .then( review => res.json(review))
-      .catch(err => res.status(400).json(err))
-  });
-
-// delete a review
-router.delete('/:id/reviews/:reviewId',
-  passport.authenticate("jwt", { session: false }),
-  (req, res) => {
-    Review
-      .findById(req.params.reviewId)
-      .then(review => {
-        if (!review) {
-          return res.status(404).json({ error: "Can't find that review" })
-        }
-        Review.deleteOne(review)
-          .then(review => res.status(200).json({ msg: "review deleted" }))
-          .catch(err => console.log(err));
-      });
-  })
-
-// update a review
-router.patch('/:id/reviews/:reviewId',
-  passport.authenticate("jwt", { session: false }),
-  (req, res) => {
-    Review.findByIdAndUpdate(
-      req.params.reviewId,
-      req.body,
-      { new: true }
-      ).then(review => res.json(review))
-        .catch(err => console.log(err))
-  });
-
 // get spot's favorites
 router.get('/:id/favorites',
   passport.authenticate('jwt', { session: false }),
@@ -175,5 +122,6 @@ router.delete('/:id/favorites/:favoriteId',
       });
   });
 
+router.use("/:spotId/reviews", reviews);
 module.exports = router;
 


### PR DESCRIPTION
create reviews routes file and move reviews routes from spots routes file into reviews routes file

didn't have anything to do with adding reviews to the spots slice of state -- I don't think we actually need to do this, we can just  re-fetch reviews whenever we land on a new spot's page